### PR TITLE
🩹 Exclusão de secção administrador

### DIFF
--- a/src/components/TabHeader.vue
+++ b/src/components/TabHeader.vue
@@ -30,15 +30,6 @@ watchPostEffect(() => {
       <q-route-tab :label="$t('titles.scheduler')" to="/schedule" />
       <q-route-tab :label="$t('label.menu')" to="/menu" />
       <q-route-tab :label="$t('label.menuCreate')" to="/menu/create" />
-      <q-route-tab
-        flat
-        color="white"
-        no-caps
-        :label="$t('admin')"
-        to="/login"
-        :disable="enableDrop"
-      >
-      </q-route-tab>
       <q-btn-dropdown
         flat
         color="white"


### PR DESCRIPTION
Exclusão da tab "Administrador" que estava constantemente desabilitada no menu e não possui uma rota/tela para redirecionar o usuário. 

Antes: 
<img width="701" height="90" alt="image" src="https://github.com/user-attachments/assets/47b5ddd7-fbf0-4f7f-8976-5aa4ecf4fcf4" />


Depois: 
<img width="583" height="93" alt="image" src="https://github.com/user-attachments/assets/1098d1d0-16ab-44d9-951f-31bcbb01c612" />
